### PR TITLE
Handle stripe webhooks for donations and subscriptions

### DIFF
--- a/source/src/lib/helper.ts
+++ b/source/src/lib/helper.ts
@@ -5,7 +5,7 @@ export async function generateUnsubscribeLink(subscriptionId: string, email: str
     // Create a secure token that expires in 7 days
     const token = await createExpiringToken(subscriptionId, email);
 
-    return `${process.env.NEXT_PUBLIC_SITE_URL}/api/cancel-subscription?token=${token}&sub=${encodeURIComponent(subscriptionId)}`;
+    return `${process.env.NEXT_PUBLIC_SITE_URL}/api/stripe/cancel-subscription?token=${token}&sub=${encodeURIComponent(subscriptionId)}`;
 }
 
 export async function createExpiringToken(subscriptionId: string, email: string): Promise<string> {


### PR DESCRIPTION
Update unsubscribe link to point to the correct Stripe cancellation API route.

This change ensures that the unsubscribe link sent in recurring donation emails directs users to the functional API endpoint (`/api/stripe/cancel-subscription`), enabling them to manage or cancel their subscriptions as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bdcb75e-1692-4d86-bec7-2e3e003a6063">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bdcb75e-1692-4d86-bec7-2e3e003a6063">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

