### PR TITLE
Handle stripe webhooks for donations and subscriptions

### DIFF
--- a/source/src/app/(main)/donations/manage/page.tsx
+++ b/source/src/app/(main)/donations/manage/page.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useSearchParams } from 'next/navigation'
+
+export default function ManageDonationsPage() {
+  const searchParams = useSearchParams()
+  const cancelled = searchParams.get('cancelled') === 'true'
+  const error = searchParams.get('error')
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10">
+      <h1 className="text-2xl font-semibold mb-4">Manage your donations</h1>
+
+      {cancelled && (
+        <div className="mb-6 rounded border border-green-300 bg-green-50 p-4 text-green-800">
+          Your recurring donation has been cancelled. A confirmation email has been sent.
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-6 rounded border border-red-300 bg-red-50 p-4 text-red-800">
+          {error === 'invalid_link' && 'The unsubscribe link is invalid.'}
+          {error === 'expired_link' && 'The unsubscribe link has expired. Please request a new one.'}
+          {error === 'cancellation_failed' && 'We could not cancel the subscription. Please try again or contact support.'}
+        </div>
+      )}
+
+      <p>Here you can manage your donation settings. (Coming soon)</p>
+    </div>
+  )
+}

--- a/source/src/app/(main)/donations/unsubscribe/page.tsx
+++ b/source/src/app/(main)/donations/unsubscribe/page.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useMemo } from 'react'
+
+export default function UnsubscribePage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const token = searchParams.get('token') || ''
+  const subscriptionId = searchParams.get('sub') || ''
+
+  const isInvalid = useMemo(() => !token || !subscriptionId, [token, subscriptionId])
+
+  const onConfirm = () => {
+    if (isInvalid) {
+      router.replace('/donations/manage?error=invalid_link')
+      return
+    }
+    // Navigate to the API route which verifies the token, cancels the subscription,
+    // and then redirects to the manage page with a status query.
+    window.location.href = `/api/stripe/cancel-subscription?token=${encodeURIComponent(token)}&sub=${encodeURIComponent(subscriptionId)}`
+  }
+
+  const onCancel = () => {
+    router.replace('/donations/manage')
+  }
+
+  return (
+    <div className="mx-auto max-w-xl px-6 py-12">
+      <h1 className="text-2xl font-semibold mb-4">Cancel recurring donation</h1>
+      {isInvalid ? (
+        <p className="text-red-600">This link is invalid or incomplete. Please request a new unsubscribe link.</p>
+      ) : (
+        <>
+          <p className="mb-6">Are you sure you want to cancel your recurring donation (Subscription ID: <span className="font-mono">{subscriptionId}</span>)? This will stop future scheduled charges.</p>
+          <div className="flex gap-3">
+            <button onClick={onConfirm} className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700">Yes, cancel</button>
+            <button onClick={onCancel} className="bg-gray-200 px-4 py-2 rounded hover:bg-gray-300">No, keep it</button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/source/src/emails/donation-receipt.ejs
+++ b/source/src/emails/donation-receipt.ejs
@@ -209,6 +209,13 @@
                     Thank you for your faithful support!
                 </div>
 
+                <% if (isRecurring && unsubscribeLink) { %>
+                    <p style="text-align: center; margin: 10px 0 20px;">
+                        You can manage or cancel your recurring donation at any time here:
+                        <a href="<%= unsubscribeLink %>">Unsubscribe</a>
+                    </p>
+                <% } %>
+
                 <% if (receiptUrl) { %>
                     <div style="text-align: center;">
                         <a href="<%= receiptUrl %>" class="receipt-btn">Download Official Receipt</a>

--- a/source/src/lib/helper.ts
+++ b/source/src/lib/helper.ts
@@ -1,20 +1,9 @@
-import jwt from 'jsonwebtoken';
+import { createExpiringToken } from './utils';
 
 
 export async function generateUnsubscribeLink(subscriptionId: string, email: string): Promise<string> {
     // Create a secure token that expires in 7 days
     const token = await createExpiringToken(subscriptionId, email);
 
-    return `${process.env.NEXT_PUBLIC_SITE_URL}/api/cancel-subscription?token=${token}&sub=${encodeURIComponent(subscriptionId)}`;
-}
-
-export async function createExpiringToken(subscriptionId: string, email: string): Promise<string> {
-    // Use JWT or similar to create a signed token
-    const payload = {
-        sub: subscriptionId,
-        email: email,
-        exp: Math.floor(Date.now() / 1000) + (60 * 60 * 24 * 7) // 7 days expiry
-    };
-
-    return jwt.sign(payload, process.env.SECRET_KEY_FOR_TOKENS!);
+    return `${process.env.NEXT_PUBLIC_SITE_URL}/donations/unsubscribe?token=${token}&sub=${encodeURIComponent(subscriptionId)}`;
 }


### PR DESCRIPTION
Implement end-to-end unsubscribe flow for recurring donations.

This PR allows users to cancel their recurring donations via a secure link included in subscription confirmation and recurring donation receipt emails. The flow guides users through a confirmation page before triggering the Stripe subscription cancellation, with the webhook handling the final cancellation email.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ec3bd92-dcf4-4eba-a594-b4a930fddbfe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ec3bd92-dcf4-4eba-a594-b4a930fddbfe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

